### PR TITLE
Issue 69: extension check

### DIFF
--- a/sdv/modeler.py
+++ b/sdv/modeler.py
@@ -178,7 +178,7 @@ class Modeler:
             extension = child_table.groupby(fk)
             extension = extension.apply(self._extension_from_group(transformed_child_table))
 
-            if extension is not None:
+            if len(extension):
                 # keep track of child column indices
                 end = max(end, start + extension.shape[1])
 


### PR DESCRIPTION
When generating extensions, checks for the extension to be empty by using length of the extension instead of type-checking to `None`, as there can be empty extensions that don't equal to `None`.

Resolves #69 