### PR TITLE
Issue 76: Update requirements to copulas=0.2.1

### DIFF
--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -1,6 +1,7 @@
 import random
 
 import pandas as pd
+from copulas import get_qualified_name
 
 import exrex
 
@@ -264,13 +265,18 @@ class Sampler:
         distributions = {}
         for label_index, i in enumerate(range(cov_size, totalcols, 2)):
             distributions[labels[label_index]] = {
+                'type': get_qualified_name(self.modeler.distribution),
+                'fitted': True,
                 'std': abs(params.iloc[:, i]),  # Pending for issue
                 'mean': params.iloc[:, i + 1],  # https://github.com/HDI-Project/SDV/issues/58
             }
 
         model_params = {
             'covariance': covariance,
-            'distribs': distributions
+            'distribs': distributions,
+            'type': get_qualified_name(self.modeler.model),
+            'fitted': True,
+            'distribution': get_qualified_name(self.modeler.distribution)
         }
 
         return self.modeler.model.from_dict(model_params)

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ with open('HISTORY.md') as history_file:
 
 install_requires = [
     'boto3>=1.7.47',
-    'exrex==0.10.5',
-    'numpy==1.13.1',
-    'pandas==0.22.0',
-    'scipy==0.19.1',
-    'scikit-learn==0.19.1',
-    'copulas==0.2.1',
-    'rdt==0.1.0'
+    'exrex>=0.10.5',
+    'numpy>=1.13.1',
+    'pandas>=0.22.0',
+    'scipy>=0.19.1',
+    'scikit-learn>=0.19.1',
+    'copulas>=0.2.1',
+    'rdt>=0.1.0'
 ]
 
 setup_requires = ['pytest-runner', ]
@@ -44,7 +44,7 @@ development_requires = [
     'autopep8>=1.3.5',
     'twine>=1.10.0',
     'wheel>=0.30.0',
-    'm2r==0.2.0'
+    'm2r>=0.2.0'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'pandas==0.22.0',
     'scipy==0.19.1',
     'scikit-learn==0.19.1',
-    'copulas==0.2.0',
+    'copulas==0.2.1',
     'rdt==0.1.0'
 ]
 


### PR DESCRIPTION
The requirement for copulas has been updated to the latest version (0.2.1). Minor changes have been made to the parameter sampling to adapt to the latest changes.

Resolves #76 