### PR TITLE
Issue 73: Raise exception unsupported datasets

### DIFF
--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -1,6 +1,7 @@
 import random
 
 import pandas as pd
+from copulas import get_qualified_name
 
 import exrex
 
@@ -264,13 +265,18 @@ class Sampler:
         distributions = {}
         for label_index, i in enumerate(range(cov_size, totalcols, 2)):
             distributions[labels[label_index]] = {
+                'type': get_qualified_name(self.modeler.distribution),
+                'fitted': True,
                 'std': abs(params.iloc[:, i]),  # Pending for issue
                 'mean': params.iloc[:, i + 1],  # https://github.com/HDI-Project/SDV/issues/58
             }
 
         model_params = {
             'covariance': covariance,
-            'distribs': distributions
+            'distribs': distributions,
+            'type': get_qualified_name(self.modeler.model),
+            'fitted': True,
+            'distribution': get_qualified_name(self.modeler.distribution)
         }
 
         return self.modeler.model.from_dict(model_params)

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -11,41 +11,72 @@ from sdv.sampler import Sampler
 
 
 class SDV:
-    """Class to do modeling and sampling all in one."""
+    """Class to do modeling and sampling all in one.
+
+    Args:
+        meta_file_name (str): Path to the metadata file.
+        data_loader_type (str)
+    """
 
     def __init__(self, meta_file_name, data_loader_type='csv'):
-        """Initialize sdv class."""
         self.meta_file_name = meta_file_name
         self.sampler = None
 
+    def _check_unsupported_dataset_structure(self):
+        """Checks that no table has two parents."""
+        tables = self.dn.tables.keys()
+        amount_parents = [len(self.dn.get_parents(table)) <= 1 for table in tables]
+        if not all(amount_parents):
+            raise ValueError('Some tables have multiple parents, which is not supported yet.')
+
     def fit(self):
-        """Transform the data and model the database."""
+        """Transform the data and model the database.
+
+        Raises:
+            ValueError: If the provided dataset has an unsupported structure.
+        """
         data_loader = CSVDataLoader(self.meta_file_name)
         self.dn = data_loader.load_data()
-        # transform data
+
+        self._check_unsupported_dataset_structure()
+
         self.dn.transform_data()
         self.modeler = Modeler(self.dn)
         self.modeler.model_database()
         self.sampler = Sampler(self.dn, self.modeler)
 
     def sample_rows(self, table_name, num_rows):
-        """Wrapper for Sampler.sample_rows."""
+        """Sample `num_rows` rows from the given table.
+
+        Args:
+            table_name(str): Name of the table to sample from.
+            num_rows(int): Amount of rows to sample.
+        """
         if self.sampler is None:
             raise NotFittedError('SDV instance has not been fitted')
 
         return self.sampler.sample_rows(table_name, num_rows)
 
     def sample_table(self, table_name):
-        """Wrapper for Sampler.sample_table."""
+        """Samples the given table to its original size.
+
+        Args:
+            table_name (str): Table to sample.
+        """
         if self.sampler is None:
             raise NotFittedError('SDV instance has not been fitted')
 
         return self.sampler.sample_table(table_name)
 
     def sample_all(self, num_rows=5):
-        """Wrapper for Sampler.sample_all."""
+        """Sample the whole dataset.
+
+        Args:
+            num_rows (int): Amount of rows to sample.
+        """
         if self.sampler is None:
             raise NotFittedError('SDV instance has not been fitted')
+
         return self.sampler.sample_all(num_rows)
 
     def save(self, filename):

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,13 @@ with open('HISTORY.md') as history_file:
 
 install_requires = [
     'boto3>=1.7.47',
-    'exrex==0.10.5',
-    'numpy==1.13.1',
-    'pandas==0.22.0',
-    'scipy==0.19.1',
-    'scikit-learn==0.19.1',
-    'copulas==0.2.1',
-    'rdt==0.1.0'
+    'exrex>=0.10.5',
+    'numpy>=1.13.1',
+    'pandas>=0.22.0',
+    'scipy>=0.19.1',
+    'scikit-learn>=0.19.1',
+    'copulas>=0.2.1',
+    'rdt>=0.1.0'
 ]
 
 setup_requires = ['pytest-runner', ]
@@ -44,7 +44,7 @@ development_requires = [
     'autopep8>=1.3.5',
     'twine>=1.10.0',
     'wheel>=0.30.0',
-    'm2r==0.2.0'
+    'm2r>=0.2.0'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'pandas==0.22.0',
     'scipy==0.19.1',
     'scikit-learn==0.19.1',
-    'copulas==0.2.0',
+    'copulas==0.2.1',
     'rdt==0.1.0'
 ]
 

--- a/tests/sdv/test_sdv.py
+++ b/tests/sdv/test_sdv.py
@@ -1,0 +1,21 @@
+from unittest import TestCase, mock
+
+from sdv import SDV
+
+
+class TestSDV(TestCase):
+
+    def test__check_unsupported_raises(self):
+        """_check_unsupported will raise a ValueError if a table has two parents."""
+        # Setup
+        instance = SDV(meta_file_name='meta.json')
+
+        data_navigator_mock = mock.MagicMock()
+        data_navigator_mock.tables.keys.return_value = ['A', 'B']
+        data_navigator_mock.get_parents.return_value = ['X', 'Y']
+
+        instance.dn = data_navigator_mock
+
+        # Run / Check
+        with self.assertRaises(ValueError):
+            instance._check_unsupported_dataset_structure()


### PR DESCRIPTION
Added a method `SDV. _check_unsupported_dataset_structure` that checks that every table on the dataset has as most one parent table.

Resolves #73 