### PR TITLE
Issue 81: enforce sampled values in range [0,1] for  categorical columns

### DIFF
--- a/sdv/modeler.py
+++ b/sdv/modeler.py
@@ -6,6 +6,7 @@ import pandas as pd
 from copulas import get_qualified_name
 from copulas.multivariate import GaussianMultivariate, TreeTypes
 from copulas.univariate import GaussianUnivariate
+from rdt.transformers.positive_number import PositiveNumberTransformer
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -162,6 +163,15 @@ class Modeler:
                 values.append(row[:index + 1])
 
             model.covariance = np.array(values)
+            if self.model_kwargs['distribution'] == get_qualified_name(DEFAULT_DISTRIBUTION):
+                transformer = PositiveNumberTransformer({
+                    'name': 'field',
+                    'type': 'number'
+                })
+
+                for distribution in model.distribs.values():
+                    column = pd.DataFrame({'field': [distribution.std]})
+                    distribution.std = transformer.reverse_transform(column).loc[0, 'field']
 
         return pd.Series(self._flatten_dict(model.to_dict(), name))
 

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -63,15 +63,13 @@ class Sampler:
         meta = self.dn.tables[table_name].meta
         orig_meta = self._get_table_meta(self.dn.meta, table_name)
         primary_key = meta.get('primary_key')
-        categorical_fields = [
-            field['name'] for field in orig_meta['fields']
-            if field['type'] == 'categorical'
-        ]
 
-        if categorical_fields:
-            for field in categorical_fields:
-                if ((synthesized[field] < 0) | (synthesized[field] > 1)).any():
-                    synthesized[field] = self._rescale_values(synthesized[field])
+        for field in orig_meta['fields']:
+            if field['type'] == 'categorical':
+                column_name = field['name']
+                column = synthesized[column_name]
+                if ((column < 0) | (column > 1)).any():
+                    synthesized[column_name] = self._rescale_values(column)
 
         if primary_key:
             node = meta['fields'][primary_key]

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -407,7 +407,7 @@ class Sampler:
 
         return self.modeler.model.from_dict(model_parameters)
 
-    def __get_missing_valid_rows(self, synthesized, drop_indices, valid_rows, num_rows):
+    def _get_missing_valid_rows(self, synthesized, drop_indices, valid_rows, num_rows):
         """
 
         Args:
@@ -453,7 +453,7 @@ class Sampler:
                     if filtered_values.any():
                         drop_indices |= filtered_values
 
-            missing_rows, valid_rows = self.__get_missing_valid_rows(
+            missing_rows, valid_rows = self._get_missing_valid_rows(
                 synthesized, drop_indices, valid_rows, num_rows)
 
             while missing_rows:
@@ -467,7 +467,7 @@ class Sampler:
                     if filtered_values.any():
                         drop_indices |= filtered_values
 
-                missing_rows, valid_rows = self.__get_missing_valid_rows(
+                missing_rows, valid_rows = self._get_missing_valid_rows(
                     synthesized, drop_indices, valid_rows, num_rows)
 
             return valid_rows

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -358,23 +358,19 @@ class Sampler:
             'fitted': True,
             'type': distribution_name
         }
+        model_parameters['distribution'] = distribution_name
 
         distribs = model_parameters['distribs']
-        if any([distribs[key]['std'] <= 0 for key in distribs]):
-            metadata = {
-                'name': 'std',
-                'type': 'number'
-            }
-            transformer = PositiveNumberTransformer(metadata)
+        metadata = {
+            'name': 'std',
+            'type': 'number'
+        }
+        transformer = PositiveNumberTransformer(metadata)
 
-        model_parameters['distribution'] = distribution_name
-        for key in distribs:
-            distribs[key].update(distribution_kwargs)
-
-            distribution_std = distribs[key]['std']
-            if distribution_std <= 0:
-                df = pd.DataFrame({'std': [distribution_std]})
-                distribs[key]['std'] = transformer.fit_transform(df)['std'].values[0]
+        for distribution in distribs.values():
+            distribution.update(distribution_kwargs)
+            df = pd.DataFrame({'std': [distribution['std']]})
+            distribution['std'] = transformer.transform(df).loc[0, 'std']
 
         covariance = model_parameters['covariance']
         covariance = self._prepare_sampled_covariance(covariance)

--- a/tests/sdv/test_modeler.py
+++ b/tests/sdv/test_modeler.py
@@ -36,9 +36,9 @@ class ModelerTest(TestCase):
             'covariance__1__0': 0.0,
             'covariance__1__1': 1.4999999999999991,
             'distribs__a__mean': 0.0,
-            'distribs__a__std': 0.001,
+            'distribs__a__std': -6.907755278982137,
             'distribs__b__mean': 3.0,
-            'distribs__b__std': 1.632993161855452
+            'distribs__b__std': 0.4904146265058631
         })
 
         # Run
@@ -156,11 +156,11 @@ class ModelerTest(TestCase):
             'covariance__2__1': -0.7500000000000003,
             'covariance__2__2': 1.5000000000000007,
             'distribs__0__mean': 0.33333333333333331,
-            'distribs__0__std': 0.47140452079103168,
+            'distribs__0__std': -0.7520386983881371,
             'distribs__1__mean': 0.33333333333333331,
-            'distribs__1__std': 0.47140452079103168,
+            'distribs__1__std': -0.7520386983881371,
             'distribs__2__mean': 0.33333333333333331,
-            'distribs__2__std': 0.47140452079103168
+            'distribs__2__std': -0.7520386983881371
         })
         data_navigator = mock.MagicMock()
         modeler = Modeler(data_navigator)

--- a/tests/sdv/test_sampler.py
+++ b/tests/sdv/test_sampler.py
@@ -377,11 +377,11 @@ class TestSampler(TestCase):
             'distribs': {
                 0: {
                     'first': 'distribution',
-                    'std': 1
+                    'std': 0
                 },
                 1: {
                     'second': 'distribution',
-                    'std': 1
+                    'std': 0
                 }
             }
         }


### PR DESCRIPTION
A method for rescaling values into the range [0, 1] in the case some are sampled out of it. These changes should fix the bug where some times, when sampling categorical values, numbers are returned on some rows instead of the expected categories.

Resolves #81 