### PR TITLE
Issue 86: Error merging extensions on modeler.CPA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8 and isort
-	flake8 sdv tests
-	isort -c --recursive sdv tests
+	flake8 sdv tests examples
+	isort -c --recursive sdv tests examples
 
 fixlint: ## fix lint issues using autoflake, autopep8, and isort
 	find sdv -name '*.py' | xargs autoflake --in-place --remove-all-unused-imports --remove-unused-variables

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -3,8 +3,8 @@ import os
 import sys
 from timeit import default_timer as timer
 
-from sdv.sdv import SDV
 from examples.utils import download_folder
+from sdv.sdv import SDV
 
 
 def get_logger():
@@ -51,15 +51,14 @@ def run_demo(folder_name):
         'demo', folder_name, folder_name.capitalize() + '_manual_meta.json')
     sdv = SDV(meta_file)
     sdv.fit()
-    sampled_rows = {}
-    LOGGER.info('Parent map: %s',
-                sdv.dn.parent_map)
-    LOGGER.info('Transformed data: %s',
-                sdv.dn.transformed_data)
-    table_list = table_dict[folder_name]
-    for table in table_list:
-        sampled_rows[table] = sdv.sample_rows(table, 1)
-        LOGGER.info('Sampled row from %s: %s', table, sampled_rows[table])
+    sampled = sdv.sample_all()
+
+    LOGGER.info('Parent map: %s', sdv.dn.parent_map)
+    LOGGER.info('Transformed data: %s', sdv.dn.transformed_data)
+
+    for name, table in sampled.items():
+        LOGGER.info('Sampled row from %s: %s', name, table.head(3).T)
+
     end = timer()
     LOGGER.info('Total time: %s seconds', round(end-start))
 

--- a/examples/multiparent_example/multiparent_example.py
+++ b/examples/multiparent_example/multiparent_example.py
@@ -22,12 +22,13 @@ def run_example():
     # Setup
     vault = SDV('data/meta.json')
     vault.fit()
-    
+
     # Run
     result = vault.sample_all()
 
     for name, table in result.items():
         print('Samples generated for table {}:\n{}\n'.format(name, table.head(5)))
+
 
 if __name__ == '__main__':
     run_example()

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,11 +1,8 @@
+import io
 import logging
 import os
+import urllib
 import zipfile
-
-import boto3
-from botocore import UNSIGNED
-from botocore.client import Config
-from botocore.exceptions import ClientError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -16,9 +13,7 @@ SUFFIX = '.zip'
 
 def download_folder(folder_name):
     """Downloads and extracts demo folder from S3"""
-    s3 = boto3.resource('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))
     zip_name = folder_name + SUFFIX
-    zip_destination = os.path.join('demo', zip_name)
     key = os.path.join(SDV_NAME, zip_name)
 
     # If the directory doesn't exist , we create it
@@ -28,19 +23,20 @@ def download_folder(folder_name):
 
     else:
         if os.path.exists(os.path.join('demo', folder_name)):
-            LOGGER.info('Folder %s found, skipping download', folder_name)
             return
 
     # try to download files from s3
     try:
-        s3.Bucket(BUCKET_NAME).download_file(key, zip_destination)
-    except ClientError as e:
-        if e.response['Error']['Code'] == "404":
-            LOGGER.error("The object does not exist.")
-        else:
-            raise
+        url = 'https://{}.s3.amazonaws.com/{}'.format(BUCKET_NAME, key)
+        response = urllib.request.urlopen(url)
+        bytes_io = io.BytesIO(response.read())
+
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            LOGGER.error('File %s not found.', key)
+        raise
 
     # unzip folder
-    zip_ref = zipfile.ZipFile(zip_destination, 'r')
+    zip_ref = zipfile.ZipFile(bytes_io, 'r')
     zip_ref.extractall('demo')
     zip_ref.close()

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,11 +1,13 @@
+import logging
 import os
-import boto3
-import botocore
 import zipfile
 
+import boto3
 from botocore import UNSIGNED
 from botocore.client import Config
+from botocore.exceptions import ClientError
 
+LOGGER = logging.getLogger(__name__)
 
 BUCKET_NAME = 'hdi-demos'
 SDV_NAME = 'sdv-demo'
@@ -14,20 +16,27 @@ SUFFIX = '.zip'
 
 def download_folder(folder_name):
     """Downloads and extracts demo folder from S3"""
-    s3 = boto3.resource('s3', region_name='us-east-1',
-                        config=Config(signature_version=UNSIGNED))
+    s3 = boto3.resource('s3', region_name='us-east-1', config=Config(signature_version=UNSIGNED))
     zip_name = folder_name + SUFFIX
     zip_destination = os.path.join('demo', zip_name)
     key = os.path.join(SDV_NAME, zip_name)
-    # make sure directory exists
+
+    # If the directory doesn't exist , we create it
+    # If it exists, we check for the folder_name for early exit
     if not os.path.exists('demo'):
         os.makedirs('demo')
+
+    else:
+        if os.path.exists(os.path.join('demo', folder_name)):
+            LOGGER.info('Folder %s found, skipping download', folder_name)
+            return
+
     # try to download files from s3
     try:
         s3.Bucket(BUCKET_NAME).download_file(key, zip_destination)
-    except botocore.exceptions.ClientError as e:
+    except ClientError as e:
         if e.response['Error']['Code'] == "404":
-            print("The object does not exist.")
+            LOGGER.error("The object does not exist.")
         else:
             raise
 

--- a/sdv/modeler.py
+++ b/sdv/modeler.py
@@ -330,9 +330,19 @@ class Modeler:
         extended_table = self.dn.transformed_data[table]
         extensions = self._get_extensions(pk, children)
 
-        # add extensions
-        for extension in extensions:
-            extended_table = extended_table.merge(extension.reset_index(), how='left', on=pk)
+        if extensions:
+            original_pk = tables[table].data[pk]
+            transformed_pk = None
+            if not extended_table[pk].equals(original_pk):
+                transformed_pk = extended_table[pk].copy()
+                extended_table[pk] = original_pk
+
+            # add extensions
+            for extension in extensions:
+                extended_table = extended_table.merge(extension.reset_index(), how='left', on=pk)
+
+            if transformed_pk is not None:
+                extended_table[pk] = transformed_pk
 
         self.tables[table] = extended_table
 

--- a/sdv/modeler.py
+++ b/sdv/modeler.py
@@ -394,6 +394,7 @@ class Modeler:
                 self.models[table] = self.fit_model(clean_table)
 
         except (ValueError, np.linalg.linalg.LinAlgError) as error:
-            raise ValueError(MODELLING_ERROR_MESSAGE).with_traceback(error.__traceback__)
+            raise ValueError(
+                MODELLING_ERROR_MESSAGE).with_traceback(error.__traceback__) from None
 
         logger.info('Modeling Complete')

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -3,7 +3,7 @@
 """Main module."""
 import pickle
 
-from sklearn.exceptions import NotFittedError
+from copulas import NotFittedError
 
 from sdv.data_navigator import CSVDataLoader
 from sdv.modeler import Modeler

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,9 @@ with open('HISTORY.md') as history_file:
     history = history_file.read()
 
 install_requires = [
-    'boto3>=1.7.47',
     'exrex>=0.10.5',
     'numpy>=1.13.1',
     'pandas>=0.22.0',
-    'scipy>=0.19.1',
-    'scikit-learn>=0.19.1',
     'copulas>=0.2.1',
     'rdt>=0.1.2'
 ]

--- a/tests/sdv/test_modeler.py
+++ b/tests/sdv/test_modeler.py
@@ -316,7 +316,7 @@ class TestModeler(TestCase):
             'distribs__2__mean': 0.33333333333333331,
             'distribs__2__std': 0.47140452079103168
         })
-        data_navigator = mock.MagicMock()
+        data_navigator = MagicMock()
         modeler = Modeler(data_navigator)
 
         # Run


### PR DESCRIPTION
This PR contain the changes made in order to resolve #86:

- Little rework of examples/demo.py
- Make modeler.CPA work when index of parent table is not numerical.
- Make modeler.CPA work when name of foreign_key and primary_key are not the same.
- Make modeler.impute_table only iterate over columns with nulls, and only computing `mean` on numerical columns.
- Test for the aforementioned changes.
- During the changes above, a bug, where an exception was created, but not raised, was found, that has been fixed too.