### PR TITLE
Issue 93: Model amount of children

### DIFF
--- a/sdv/modeler.py
+++ b/sdv/modeler.py
@@ -36,10 +36,7 @@ class Modeler:
 
     DEFAULT_PRIMARY_KEY = 'GENERATED_PRIMARY_KEY'
 
-    def __init__(
-        self, data_navigator, model=DEFAULT_MODEL, distribution=None,
-        model_kwargs=None, amount_childs=False
-    ):
+    def __init__(self, data_navigator, model=DEFAULT_MODEL, distribution=None, model_kwargs=None):
         """Instantiates a modeler object."""
         self.tables = {}
         self.models = {}
@@ -92,7 +89,7 @@ class Modeler:
 
         return val
 
-    def _count_children_rows(self, parent_name):
+    def _count_child_rows(self, parent_name):
         """Append the number of children to the parent table.
 
         Args:
@@ -431,7 +428,7 @@ class Modeler:
     def model_database(self):
         """Use RCPA and store model for database."""
         for table in self.dn.tables:
-            self._count_children_rows(table)
+            self._count_child_rows(table)
 
         for table in self.dn.tables:
             if not self.dn.get_parents(table):

--- a/sdv/modeler.py
+++ b/sdv/modeler.py
@@ -53,7 +53,7 @@ class Modeler:
             raise ValueError(
                 '`distribution` argument is only suported for `GaussianMultivariate` model.')
 
-        if distribution:
+        if distribution is not None:
             distribution = get_qualified_name(distribution)
         else:
             distribution = get_qualified_name(DEFAULT_DISTRIBUTION)

--- a/sdv/modeler.py
+++ b/sdv/modeler.py
@@ -126,7 +126,7 @@ class Modeler:
             column_name = '{}__num_children'.format(child_name)
             parent_table.rename(columns={'value': column_name}, inplace=True)
 
-        self.dn.tables[parent_table] = Table(parent_table, parent_meta)
+        self.dn.tables[parent_name] = Table(parent_table, parent_meta)
 
     @classmethod
     def _flatten_array(cls, nested, prefix=''):

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -596,6 +596,9 @@ class Sampler:
     def _sample_child_rows(self, parent_name, parent_row, sampled_data, num_rows=None):
         """Uses parameters from parent row to synthesize child rows.
 
+        If num_rows=None and self.modeler.amount_childs=True, the amount of children will be
+        taken from the parent row, elsewhere, it will sample only 5 rows.
+
         Args:
             parent_name (str): name of parent table
             parent_row (dataframe): synthesized parent row

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -593,7 +593,7 @@ class Sampler:
         num_rows = self.dn.tables[table_name].data.shape[0]
         return self.sample_rows(table_name, num_rows)
 
-    def _sample_child_rows(self, parent_name, parent_row, sampled_data, num_rows=5):
+    def _sample_child_rows(self, parent_name, parent_row, sampled_data, num_rows=None):
         """Uses parameters from parent row to synthesize child rows.
 
         Args:
@@ -608,13 +608,13 @@ class Sampler:
 
         children = self.dn.get_children(parent_name)
         for child in children:
-            if self.modeler.amount_childs:
+            if self.modeler.amount_childs and num_rows is None:
                 col_name = '{}__num_children'.format(child)
-                amount_child_rows = parent_row[col_name].values[0]
+                num_rows = parent_row.loc[0, col_name]
             else:
-                amount_child_rows = 5
+                num_rows = 5
 
-            rows = self.sample_rows(child, amount_child_rows)
+            rows = self.sample_rows(child, num_rows)
 
             if child in sampled_data:
                 sampled_data[child] = pd.concat([sampled_data[child], rows])

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -1,11 +1,10 @@
 import random
 
+import exrex
 import numpy as np
 import pandas as pd
 from copulas import get_qualified_name
 from rdt.transformers.positive_number import PositiveNumberTransformer
-
-import exrex
 
 GAUSSIAN_COPULA = 'copulas.multivariate.gaussian.GaussianMultivariate'
 
@@ -188,7 +187,8 @@ class Sampler:
         self.sampled = self.update_mapping_list(self.sampled, table_name, sample_info)
 
         # filter out parameters
-        labels = list(self.dn.tables[table_name].data)
+        raw_table = self.dn.tables[table_name].data
+        labels = [label for label in raw_table if '__num_children' not in label]
         reverse_columns = [
             transformer[1] for transformer in self.dn.ht.transformers
             if table_name in transformer

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -1,10 +1,11 @@
 import random
 
-import exrex
 import numpy as np
 import pandas as pd
 from copulas import get_qualified_name
 from rdt.transformers.positive_number import PositiveNumberTransformer
+
+import exrex
 
 GAUSSIAN_COPULA = 'copulas.multivariate.gaussian.GaussianMultivariate'
 
@@ -593,7 +594,7 @@ class Sampler:
         num_rows = self.dn.tables[table_name].data.shape[0]
         return self.sample_rows(table_name, num_rows)
 
-    def _sample_child_rows(self, parent_name, parent_row, sampled_data, num_rows=None):
+    def _sample_child_rows(self, parent_name, parent_row, sampled_data):
         """Uses parameters from parent row to synthesize child rows.
 
         If num_rows=None and self.modeler.amount_childs=True, the amount of children will be
@@ -603,7 +604,6 @@ class Sampler:
             parent_name (str): name of parent table
             parent_row (dataframe): synthesized parent row
             sample_data (dict): maps table name to sampled data
-            num_rows (int): number of rows to synthesize per parent row
 
         Returns:
             synthesized children rows
@@ -611,11 +611,8 @@ class Sampler:
 
         children = self.dn.get_children(parent_name)
         for child in children:
-            if self.modeler.amount_childs and num_rows is None:
-                col_name = '{}__num_children'.format(child)
-                num_rows = parent_row.loc[0, col_name]
-            else:
-                num_rows = 5
+            col_name = '{}__num_children'.format(child)
+            num_rows = parent_row.loc[0, col_name]
 
             rows = self.sample_rows(child, num_rows)
 

--- a/sdv/sampler.py
+++ b/sdv/sampler.py
@@ -597,9 +597,6 @@ class Sampler:
     def _sample_child_rows(self, parent_name, parent_row, sampled_data):
         """Uses parameters from parent row to synthesize child rows.
 
-        If num_rows=None and self.modeler.amount_childs=True, the amount of children will be
-        taken from the parent row, elsewhere, it will sample only 5 rows.
-
         Args:
             parent_name (str): name of parent table
             parent_row (dataframe): synthesized parent row

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -19,19 +19,18 @@ class SDV:
         model (type): Class of model to use.
         distribution (type): Class of distribution to use. Will be deprecated shortly.
         model_kwargs (dict): Keyword arguments to pass to model.
-        amount_childs(bool): Wheter or not model the amount of child rows.
+
     """
 
     def __init__(
         self, meta_file_name, data_loader_type='csv', model=DEFAULT_MODEL, distribution=None,
-        model_kwargs=None, amount_childs=False
+        model_kwargs=None
     ):
         self.meta_file_name = meta_file_name
         self.sampler = None
         self.model = model
         self.distribution = distribution
         self.model_kwargs = model_kwargs
-        self.amount_childs = amount_childs
 
     def _check_unsupported_dataset_structure(self):
         """Checks that no table has two parents."""
@@ -53,8 +52,10 @@ class SDV:
 
         self.dn.transform_data()
         self.modeler = Modeler(
-            self.dn, model=self.model, distribution=self.distribution,
-            model_kwargs=self.model_kwargs, amount_childs=self.amount_childs
+            data_navigator=self.dn,
+            model=self.model,
+            distribution=self.distribution,
+            model_kwargs=self.model_kwargs
         )
         self.modeler.model_database()
         self.sampler = Sampler(self.dn, self.modeler)

--- a/tests/sdv/test_modeler.py
+++ b/tests/sdv/test_modeler.py
@@ -977,6 +977,7 @@ class TestModeler(TestCase):
                 'use': True
             }
         ]
+        data_navigator.get_children.return_value = {'children'}
         modeler = Modeler(data_navigator=data_navigator)
         expected_result = pd.DataFrame({
             'parent_id': list(range(1, 3)),

--- a/tests/sdv/test_modeler.py
+++ b/tests/sdv/test_modeler.py
@@ -464,8 +464,8 @@ class TestModeler(TestCase):
     @patch('sdv.modeler.Modeler.fit_model')
     @patch('sdv.modeler.Modeler.impute_table')
     @patch('sdv.modeler.Modeler.RCPA')
-    @patch('sdv.modeler.Modeler._count_children_rows')
-    def test_model_database(self, children_mock, rcpa_mock, impute_mock, fit_mock):
+    @patch('sdv.modeler.Modeler._count_child_rows')
+    def test_model_database(self, child_mock, rcpa_mock, impute_mock, fit_mock):
         """model_database computes conditions between tables and models them."""
         # Setup
         data_navigator = MagicMock(spec=DataNavigator)
@@ -500,7 +500,7 @@ class TestModeler(TestCase):
             (('table_C',), ),
         ]
 
-        assert children_mock.call_args_list == [
+        assert child_mock.call_args_list == [
             (('table_A',), ),
             (('table_B',), ),
             (('table_C',), ),
@@ -525,8 +525,8 @@ class TestModeler(TestCase):
             'table_C': 'model_for_TABLE_C'
         }
 
-    @patch('sdv.modeler.Modeler._count_children_rows')
-    def test_model_database_gaussian_copula_single_table(self, children_mock):
+    @patch('sdv.modeler.Modeler._count_child_rows')
+    def test_model_database_gaussian_copula_single_table(self, child_mock):
         """model_database can model a single table using the gausian copula model."""
         # Setup
         data_navigator = MagicMock(spec=DataNavigator)
@@ -619,10 +619,10 @@ class TestModeler(TestCase):
 
         assert isinstance(samples, pd.DataFrame)
         assert samples.equals(sampler.dn.ht.reverse_transform_table.return_value)
-        children_mock.assert_called_once_with('table_name')
+        child_mock.assert_called_once_with('table_name')
 
-    @patch('sdv.modeler.Modeler._count_children_rows')
-    def test_model_database_kde_distribution(self, children_mock):
+    @patch('sdv.modeler.Modeler._count_child_rows')
+    def test_model_database_kde_distribution(self, child_mock):
         """model_database works fine with kde distribution."""
         # Setup
         data_navigator = MagicMock(spec=DataNavigator)
@@ -708,10 +708,10 @@ class TestModeler(TestCase):
             (('table_name', ), ),
             (('table_name', ), )
         ]
-        children_mock.assert_called_once_with('table_name')
+        child_mock.assert_called_once_with('table_name')
 
-    @patch('sdv.modeler.Modeler._count_children_rows')
-    def test_model_database_vine_modeler_single_table(self, children_mock):
+    @patch('sdv.modeler.Modeler._count_child_rows')
+    def test_model_database_vine_modeler_single_table(self, child_mock):
         """model_database works fine with vine modeler."""
         # Setup
         data_navigator = MagicMock(spec=DataNavigator)
@@ -801,7 +801,7 @@ class TestModeler(TestCase):
         samples = sampler.sample_table('table_name')
 
         assert samples.equals(reverse_transform_dataframe)
-        children_mock.assert_called_once_with('table_name')
+        child_mock.assert_called_once_with('table_name')
 
     def test__flatten_dict_flat_dict(self):
         """_flatten_dict don't modify flat dicts."""
@@ -957,8 +957,8 @@ class TestModeler(TestCase):
         # Check
         assert result == expected_result
 
-    def test__count_children_rows_single_children(self):
-        """_count_children_rows appends a column to the parent table with the number of childs."""
+    def test__count_child_rows_single_children(self):
+        """_count_child_rows appends a column to the parent table with the number of childs."""
         # Setup
         data_navigator = MagicMock(spec=DataNavigator)
         parent_table = pd.DataFrame({'parent_id': list(range(1, 3))})
@@ -1025,7 +1025,7 @@ class TestModeler(TestCase):
         }, columns=['parent_id', 'children__num_children'])
 
         # Run
-        result = modeler._count_children_rows('parent')
+        result = modeler._count_child_rows('parent')
 
         # Check
         assert result is None

--- a/tests/sdv/test_modeler.py
+++ b/tests/sdv/test_modeler.py
@@ -982,7 +982,7 @@ class TestModeler(TestCase):
         expected_result = pd.DataFrame({
             'parent_id': list(range(1, 3)),
             'children__num_children': [2, 3]
-        })
+        }, columns=['parent_id', 'children__num_children'])
 
         # Run
         result = modeler._count_children_rows('parent')

--- a/tests/sdv/test_modeler.py
+++ b/tests/sdv/test_modeler.py
@@ -189,8 +189,8 @@ class TestModeler(TestCase):
         data_navigator.get_children.assert_called_once_with('table')
         extension.reset_index.assert_called_once_with()
         extended_table.drop.assert_not_called()
-        extended_table.__setitem__.assert_called_once()
         call_args_list = extended_table.__setitem__.call_args_list
+        assert len(call_args_list) == 1
         args, kwargs = call_args_list[0]
         assert kwargs == {}
         assert len(args) == 2

--- a/tests/sdv/test_sampler.py
+++ b/tests/sdv/test_sampler.py
@@ -170,7 +170,7 @@ class TestSampler(TestCase):
 
         # Check
         assert result.shape[0] == 5
-        assert (result.columns == raw_data.columns).all()
+        assert all(column in raw_data.columns for column in result.columns)
 
         # Primary key columns are sampled values
         assert len(result['CUSTOMER_ID'].unique()) != 1
@@ -187,7 +187,7 @@ class TestSampler(TestCase):
 
         # Check
         assert result.shape[0] == 5
-        assert (result.columns == raw_data.columns).all()
+        assert all(column in raw_data.columns for column in result.columns)
 
         # Foreign key columns are all the same
         unique_foreign_keys = result['CUSTOMER_ID'].unique()


### PR DESCRIPTION
Resolve #93 

Allow to model the amount of child rows for each parent row and using it when sampling.