### PR TITLE
Issue 52: Add evaluation metrics

### DIFF
--- a/sdv/metrics.py
+++ b/sdv/metrics.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+import scipy as sp
 
 
 def sum_square_diff(x, y):
@@ -71,8 +72,8 @@ DEFAULT_SCORES = (
 DEFAULT_METRICS = (
     np.mean,
     np.std,
-    np.stats.skew,
-    np.stats.kurt
+    sp.stats.skew,
+    sp.stats.kurtosis
 )
 
 
@@ -94,26 +95,29 @@ def get_metric_values(real, synth, metric):
     return real_values, synth_values
 
 
-def score_table(real, synth, scores=DEFAULT_SCORES, metrics=DEFAULT_METRICS):
+def score_stats_table(real, synth, metrics=DEFAULT_METRICS, scores=DEFAULT_SCORES):
     """Score the synthesized data using the given scores and metrics.
 
     Args:
-        real(pandas.DataFrame)
-        synth(pandas.DataFrame)
-        scores(list(callable))
-        metrics(list(callable))
+        real(pandas.DataFrame): Table of real data.
+        synth(pandas.DataFrame): Table of synthesized data.
+        metrics(list(callable)): List of metrics.
+        scores(list(callable)): List of scores.
 
     Return:
-        pandas.DataFrame
-    
+        pandas.DataFrame: DataFrame whose columns are the names of the scores, as index the name
+                          of the metric, and as a values, the value of the score applied to the
+                          metric of both tables.
+
     """
     score_values = defaultdict(list)
     index = []
+    columns = [score.__name__ for score in scores]
     for metric in metrics:
-        index.append(metric.name)
+        index.append(metric.__name__)
         real_metric, synth_metric = get_metric_values(real, synth, metric)
         for score in scores:
             score_value = score(real_metric, synth_metric)
             score_values[score.__name__].append(score_value)
 
-    return pd.DataFrame(score_values, index=index)
+    return pd.DataFrame(score_values, index=index, columns=columns)

--- a/sdv/metrics.py
+++ b/sdv/metrics.py
@@ -1,0 +1,119 @@
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+
+
+def sum_square_diff(x, y):
+    """Compute the sum of the square differences of two vectors.
+
+    Args:
+        x(np.ndarray): First vector.
+        y(np.ndarray): Second vector.
+
+    Returns:
+        float: Sum of the squared difference.
+
+    """
+    return((x - y)**2).sum()
+
+
+def r2_score(expected, observed):
+    """Compute R2 score.
+    Args:
+        expected(numpy.ndarray): Ground truth.
+        observed(numpy.ndaraay): Observed values.
+
+    Returns:
+        float: R2 score.
+
+    """
+    numerator = sum_square_diff(expected, observed)
+    denominator = sum_square_diff(expected, expected.mean())
+
+    return 1 - (numerator / denominator)
+
+
+def mse(expected, observed):
+    """Compute the Mean Squared Error.
+
+    Args:
+        expected(numpy.ndarray): Ground truth.
+        observed(numpy.ndaraay): Observed values.
+
+    Returns:
+        float: Mean squared error.
+
+    """
+    return np.average((expected - observed) ** 2, axis=0)
+
+
+def rmse(expected, observed):
+    """Compute the Root Mean Squared Error.
+
+    Args:
+        expected(numpy.ndarray): Ground truth.
+        observed(numpy.ndaraay): Observed values.
+
+    Returns:
+        float: Root mean squared error.
+
+    """
+    return np.sqrt(mse(expected, observed))
+
+
+DEFAULT_SCORES = (
+    mse,
+    rmse,
+    r2_score
+)
+
+DEFAULT_METRICS = (
+    np.mean,
+    np.std,
+    np.stats.skew,
+    np.stats.kurt
+)
+
+
+def get_metric_values(real, synth, metric):
+    """Compute the metric values for the given tables.
+
+    Args:
+        real(pandas.DataFrame): Real data.
+        synth(pandas.DataFrame): Synthesized data.
+        metric(callable): Callable that accepts columns and returns real-values.
+
+    Return:
+        tuple(numpy.ndarray, numpy.ndarray): Result of metric computed column-wise on both tables.
+
+    """
+    real_values = real.apply(metric, axis=0).values
+    synth_values = synth.apply(metric, axis=0).values
+
+    return real_values, synth_values
+
+
+def score_table(real, synth, scores=DEFAULT_SCORES, metrics=DEFAULT_METRICS):
+    """Score the synthesized data using the given scores and metrics.
+
+    Args:
+        real(pandas.DataFrame)
+        synth(pandas.DataFrame)
+        scores(list(callable))
+        metrics(list(callable))
+
+    Return:
+        pandas.DataFrame
+    
+    """
+    score_values = defaultdict(list)
+    index = []
+    for metric in metrics:
+        index.append(metric.name)
+        real_metric, synth_metric = get_metric_values(real, synth, metric)
+        for score in scores:
+            score_value = score(real_metric, synth_metric)
+            score_values[score.__name__].append(score_value)
+
+    return pd.DataFrame(score_values, index=index)

--- a/sdv/metrics.py
+++ b/sdv/metrics.py
@@ -21,6 +21,7 @@ def sum_square_diff(x, y):
 
 def r2_score(expected, observed):
     """Compute R2 score.
+
     Args:
         expected(numpy.ndarray): Ground truth.
         observed(numpy.ndaraay): Observed values.
@@ -126,7 +127,7 @@ def score_stats_table(real, synth, metrics=DEFAULT_METRICS, scores=DEFAULT_SCORE
 def score_stats_dataset(real, synth, metrics=DEFAULT_METRICS, scores=DEFAULT_SCORES):
     """Compute stats score for all tables.
 
-        Args:
+    Args:
         real(dict[str, pandas.DataFrame]): Map of names and tables of real data.
         synth(dict[str, pandas.DataFrame]): Map of names and tables of synthesized data.
         metrics(list(callable)): List of metrics.
@@ -158,7 +159,8 @@ def score_categorical_coverage(real, synth, categorical_columns):
         categorical_columns(list[str]): List of labels of categorical columns.
 
     Returns:
-        float: Proportion of u
+        float: Proportion of categorical combinations.
+
     """
     if not (real.shape[0] and synth.shape[0]):
         raise ValueError("Can't score empty tables.")

--- a/tests/sdv/test_metrics.py
+++ b/tests/sdv/test_metrics.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+
+from sdv.metrics import get_metric_values
+
+
+class TestGetMetricValues(TestCase):
+
+    def test_single_column(self):
+        # Setup
+        real = pd.DataFrame({'a': range(10)})
+        synth = pd.DataFrame({'a': range(20, 10, -1)})
+        metric = np.mean
+
+        expected_result = (
+            np.array([4.5]),
+            np.array([15.5])
+        )
+
+        # Run
+        result = get_metric_values(real, synth, metric)
+
+        # Check
+        assert result == expected_result
+
+    def test_multiple_columns(self):
+        # Setup
+        real = pd.DataFrame({
+            'a': range(10),
+            'b': range(10, 20)
+        })
+        synth = pd.DataFrame({
+            'a': range(20, 10, -1),
+            'b': range(10, 0, -1)
+        })
+        metric = np.mean
+
+        expected_real = np.array([4.5, 14.5])
+        expected_synth = np.array([15.5, 5.5])
+
+        # Run
+        result_real, result_synth = get_metric_values(real, synth, metric)
+
+        # Check
+        np.testing.assert_equal(result_real, expected_real)
+        np.testing.assert_equal(result_synth, expected_synth)

--- a/tests/sdv/test_metrics.py
+++ b/tests/sdv/test_metrics.py
@@ -1,9 +1,11 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
+import scipy as sp
 
-from sdv.metrics import get_metric_values
+from sdv.metrics import get_metric_values, mse, r2_score, rmse, score_stats_table
 
 
 class TestGetMetricValues(TestCase):
@@ -46,3 +48,73 @@ class TestGetMetricValues(TestCase):
         # Check
         np.testing.assert_equal(result_real, expected_real)
         np.testing.assert_equal(result_synth, expected_synth)
+
+
+class TestScoreStatsTable(TestCase):
+
+    @patch('sdv.metrics.get_metric_values', autospec=True)
+    def test_default_call(self, metric_mock):
+        # Setup
+        real = 'real_data'
+        synth = 'synth_data'
+
+        metric_mock.side_effect = [
+            ('real_mean', 'synth_mean'),
+            ('real_std', 'synth_std'),
+            ('real_skew', 'synth_skew'),
+            ('real_kurt', 'synth_kurt')
+        ]
+
+        def mock_result(name):
+            def f(*args):
+                return '{}_{}'.format(name, args[0].split('_')[1])
+
+            return f
+
+        mse_mock = MagicMock(spec=mse, side_effect=mock_result('mse'), __name__='mse')
+        rmse_mock = MagicMock(spec=rmse, side_effect=mock_result('rmse'), __name__='rmse')
+        r2_mock = MagicMock(
+            spec=r2_score,
+            side_effect=mock_result('r2_score'),
+            __name__='r2_score'
+        )
+
+        scores = [mse_mock, rmse_mock, r2_mock]
+        columns = ['mse', 'rmse', 'r2_score']
+        index = ['mean', 'std', 'skew', 'kurtosis']
+        values = [
+            ['{}_{}'.format(score, metric[:4]) for score in columns]
+            for metric in index
+        ]
+        expected_result = pd.DataFrame(values, columns=columns, index=index)
+
+        # Run
+        result = score_stats_table(real, synth, scores=scores)
+
+        # Check
+        assert result.equals(expected_result)
+        assert metric_mock.call_args_list == [
+            (('real_data', 'synth_data', np.mean), {}),
+            (('real_data', 'synth_data', np.std), {}),
+            (('real_data', 'synth_data', sp.stats.skew), {}),
+            (('real_data', 'synth_data', sp.stats.kurtosis), {}),
+
+        ]
+        assert mse_mock.call_args_list == [
+            (('real_mean', 'synth_mean'), {}),
+            (('real_std', 'synth_std'), {}),
+            (('real_skew', 'synth_skew'), {}),
+            (('real_kurt', 'synth_kurt'), {}),
+        ]
+        assert rmse_mock.call_args_list == [
+            (('real_mean', 'synth_mean'), {}),
+            (('real_std', 'synth_std'), {}),
+            (('real_skew', 'synth_skew'), {}),
+            (('real_kurt', 'synth_kurt'), {}),
+        ]
+        assert r2_mock.call_args_list == [
+            (('real_mean', 'synth_mean'), {}),
+            (('real_std', 'synth_std'), {}),
+            (('real_skew', 'synth_skew'), {}),
+            (('real_kurt', 'synth_kurt'), {}),
+        ]

--- a/tests/sdv/test_metrics.py
+++ b/tests/sdv/test_metrics.py
@@ -7,7 +7,84 @@ import scipy as sp
 
 from sdv.metrics import (
     get_metric_values, mse, r2_score, rmse, score_categorical_coverage, score_stats_dataset,
-    score_stats_table)
+    score_stats_table, sum_square_diff)
+
+
+class TestScores(TestCase):
+
+    def test_sum_square_diff(self):
+        # Setup
+        x = np.zeros(5)
+        y = np.array(range(5))
+        expected_result = 30
+
+        # Run
+        result = sum_square_diff(x, y)
+
+        # Check
+        assert result == expected_result
+
+    @patch('sdv.metrics.sum_square_diff', autospec=True)
+    def test_r2_score(self, sum_mock):
+        """If both imputs are identical, r2_score is 1."""
+        # Setup
+        expected = MagicMock()
+        expected.mean.return_value = 'mean of expected'
+        observed = 'observed'
+
+        sum_result = sum_mock.return_value
+        div_result = sum_result.__truediv__.return_value
+        div_result.__rsub__.return_value = 'result'
+
+        # Return
+        result = r2_score(expected, observed)
+
+        # Check
+        assert result == 'result'
+
+        expected.mean.assert_called_once_with()
+        assert sum_mock.call_args_list == [
+            ((expected, 'observed'), {}),
+            ((expected, 'mean of expected'), {})
+        ]
+        sum_result.__truediv__.assert_called_once_with(sum_result)
+        div_result.__rsub__.assert_called_once_with(1)
+
+    @patch('sdv.metrics.np.average', autospec=True)
+    def test_mse(self, average_mock):
+        # Setup
+        expected = MagicMock()
+        diff_mock = expected.__sub__.return_value
+        diff_mock.__pow__.return_value = 'squared differences'
+        observed = 'observed'
+
+        average_mock.return_value = 'average'
+
+        # Run
+        result = mse(expected, observed)
+
+        # Check
+        assert result == 'average'
+        expected.__sub__.assert_called_once_with('observed')
+        diff_mock.__pow__.assert_called_once_with(2)
+        average_mock.assert_called_once_with('squared differences', axis=0)
+
+    @patch('sdv.metrics.np.sqrt', autospec=True)
+    @patch('sdv.metrics.mse', autospec=True)
+    def test_rmse(self, mse_mock, sqrt_mock):
+        # Setup
+        expected = 'expected'
+        observed = 'observed'
+        mse_mock.return_value = 'mse value'
+        sqrt_mock.return_value = 'rmse'
+
+        # Run
+        result = rmse(expected, observed)
+
+        # Check
+        assert result == 'rmse'
+        mse_mock.assert_called_once_with('expected', 'observed')
+        sqrt_mock.assert_called_once_with('mse value')
 
 
 class TestGetMetricValues(TestCase):

--- a/tests/sdv/test_metrics.py
+++ b/tests/sdv/test_metrics.py
@@ -150,10 +150,10 @@ class TestScoreStatsDataset(TestCase):
     def test_default_call(self, score_table_mock):
         # Setup
 
-        score_table_mock.side_effect = [
-            'score_for_table_A',
-            'score_for_table_B'
-        ]
+        def score_side_effect(*args, **kwargs):
+            return 'score_for_table_{}'.format(args[0][-1])
+
+        score_table_mock.side_effect = score_side_effect
 
         real = {
             'table_A': 'real_data_for_table_A',


### PR DESCRIPTION
Resolves #52.

Added two metrics to evaluate the synthesized data.

- `score_stats_dataset`: using the computing a set of regression scores on the standarized moments of each column.

- `score_categorical_coverage`: Using the ratio of unique combinations of categorical columns.