### PR TITLE
Refactoring the way the number of rows are selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vim
+.*.swp

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -60,7 +60,7 @@ class SDV:
         self.modeler.model_database()
         self.sampler = Sampler(self.dn, self.modeler)
 
-    def sample_rows(self, table_name, num_rows, reset_primary_keys=False):
+    def sample_rows(self, table_name, num_rows, sample_children=True, reset_primary_keys=False):
         """Sample `num_rows` rows from the given table.
 
         Args:
@@ -72,7 +72,8 @@ class SDV:
             raise NotFittedError('SDV instance has not been fitted')
 
         return self.sampler.sample_rows(
-            table_name, num_rows, reset_primary_keys=reset_primary_keys)
+            table_name, num_rows, sample_children=sample_children,
+            reset_primary_keys=reset_primary_keys)
 
     def sample_table(self, table_name, reset_primary_keys=False):
         """Samples the given table to its original size.

--- a/tests/sdv/test_sampler.py
+++ b/tests/sdv/test_sampler.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pandas as pd
 
-from sdv.data_navigator import DataNavigator, Table
-from sdv.modeler import GaussianMultivariate, Modeler
+from sdv.data_navigator import DataNavigator
+from sdv.modeler import Modeler
 from sdv.sampler import Sampler
 
 
@@ -36,87 +36,6 @@ class TestSampler(TestCase):
         # Check
         assert result == expected_result
 
-    @patch('sdv.sampler.Sampler._fill_text_columns', autospec=True)
-    @patch('sdv.sampler.Sampler._get_table_meta', autospec=True)
-    def test_transform_synthesized_rows_no_pk(self, get_table_meta_mock, fill_mock):
-
-        """transform_synthesized_rows will update internal state and reverse transform rows."""
-        # Setup - Class Instantiation
-        data_navigator = MagicMock()
-        modeler = MagicMock()
-        sampler = Sampler(data_navigator, modeler)
-
-        # Setup - Mock configuration
-        table_metadata = {
-            'fields': {
-                'column_A': {
-                    'type': 'number',
-                    'subtype': 'integer'
-                },
-                'column_B': {
-                    'name': 'column',
-                    'type': 'number'
-                }
-            },
-            'primary_key': None
-        }
-        table_data = pd.DataFrame(columns=['column_A', 'column_B'])
-        test_table = Table(table_data, table_metadata)
-        data_navigator.tables = {
-            'table': test_table
-        }
-
-        data_navigator.ht.transformers = {
-            ('table', 'column_A'): None,
-            ('table', 'column_B'): None
-        }
-
-        data_navigator.ht.reverse_transform_table.return_value = pd.DataFrame({
-            'column_A': ['some', 'transformed values'],
-            'column_B': ['another', 'transformed column']
-        })
-
-        get_table_meta_mock.return_value = {
-            'original': 'meta',
-            'fields': []
-        }
-
-        fill_mock.return_value = pd.DataFrame({
-            'column_A': ['filled', 'text_values'],
-            'column_B': ['nothing', 'numerical']
-        }, columns=[column[1] for column in data_navigator.ht.transformers])
-
-        # Setup - Method arguments / expected result
-        synthesized_rows = pd.DataFrame({
-            'column_A': [1.7, 2.5],
-            'column_B': [4.7, 5.1],
-            'model_parameters': ['some', 'parameters']
-        })
-        table_name = 'table'
-
-        expected_result = pd.DataFrame({
-            'column_A': ['some', 'transformed values'],
-            'column_B': ['another', 'transformed column']
-        })
-
-        # Run
-        result = sampler._transform_synthesized_rows(synthesized_rows, table_name)
-
-        # Check - Result
-        assert result.equals(expected_result)
-
-        # Check - Mock calls
-        get_table_meta_mock.assert_called_once_with(sampler, data_navigator.meta, 'table')
-        fill_mock.assert_called_once_with(
-            sampler, synthesized_rows, ['column_A', 'column_B'], 'table')
-
-        call_args = data_navigator.ht.reverse_transform_table.call_args_list
-        assert len(call_args) == 1
-        assert len(call_args[0][0]) == 2
-        assert call_args[0][0][0].equals(fill_mock.return_value)
-        assert call_args[0][0][1] == get_table_meta_mock.return_value
-        assert call_args[0][1] == {}
-
     def test__prepare_sampled_covariance(self):
         """ """
         # Setup
@@ -140,108 +59,6 @@ class TestSampler(TestCase):
 
         # Check
         assert (result == expected_result).all().all()
-
-    @patch('sdv.sampler.Sampler._transform_synthesized_rows', autospec=True)
-    @patch('sdv.sampler.Sampler.update_mapping_list')
-    @patch('sdv.sampler.Sampler._sample_valid_rows', autospec=True)
-    @patch('sdv.sampler.Sampler._get_parent_row', autospec=True)
-    @patch('sdv.sampler.Sampler._get_primary_keys', autospec=True)
-    def test_sample_rows_parent_table(
-        self, primary_mock, parent_mock, sample_mock, update_mock, trans_mock
-    ):
-        """sample_rows samples using modeler.models if the table hasn't parents."""
-        # Setup
-        data_navigator = MagicMock(spec=DataNavigator)
-        modeler = MagicMock(spec=Modeler)
-        modeler.models = {
-            'parent_table': 'model for parent table'
-        }
-        sampler = Sampler(data_navigator=data_navigator, modeler=modeler)
-
-        primary_mock.return_value = ('primary_key', pd.Series(range(5)))
-        parent_mock.return_value = None
-        sample_mock.return_value = pd.DataFrame()
-        update_mock.return_value = {'table_name': 'samples'}
-        trans_mock.return_value = 'transformed rows'
-
-        expected_result = {'parent_table': 'transformed rows'}
-
-        # Run
-        result = sampler.sample_rows('parent_table', 5)
-
-        # Check
-        assert result == expected_result
-        assert sampler.sampled == {'table_name': 'samples'}
-
-        primary_mock.assert_called_once_with(sampler, 'parent_table', 5)
-        parent_mock.assert_called_once_with(sampler, 'parent_table')
-        sample_mock.assert_called_once_with(sampler, 'model for parent table', 5, 'parent_table')
-
-        expected_sample_info = ('primary_key', sample_mock.return_value)
-        update_mock.assert_called_once_with({}, 'parent_table', expected_sample_info)
-        trans_mock.assert_called_once_with(sampler, sample_mock.return_value, 'parent_table')
-
-    @patch('sdv.sampler.Sampler._transform_synthesized_rows', autospec=True)
-    @patch('sdv.sampler.Sampler.update_mapping_list')
-    @patch('sdv.sampler.Sampler._sample_valid_rows', autospec=True)
-    @patch('sdv.sampler.Sampler._get_extension', autospec=True)
-    @patch('sdv.sampler.Sampler._get_model', autospec=True)
-    @patch('sdv.sampler.Sampler._get_parent_row', autospec=True)
-    @patch('sdv.sampler.Sampler._get_primary_keys', autospec=True)
-    def test_sample_rows_children_table(
-        self, primary_mock, parent_mock, model_mock, extension_mock,
-        sample_mock, update_mock, trans_mock
-    ):
-        """sample_rows samples using extensions when the table has parents."""
-        # Setup
-        data_navigator = MagicMock(spec=DataNavigator)
-        data_navigator.foreign_keys = {
-            ('child_table', 'parent_name'): ('parent_pk', 'child_fk')
-        }
-        modeler = MagicMock(spec=Modeler)
-        sampler = Sampler(data_navigator=data_navigator, modeler=modeler)
-
-        primary_mock.return_value = ('primary_key', pd.Series(range(5)))
-        parent_mock.return_value = (
-            'parent_name',
-            'foreign_key',
-            pd.DataFrame({'foreign_key': [0, 1, 2]})
-        )
-
-        extension_mock.return_value = 'extension'
-        model_mock.return_value = 'model from extension'
-        sample_mock.return_value = pd.DataFrame()
-        update_mock.return_value = {'table_name': 'samples'}
-        trans_mock.return_value = 'transformed_rows'
-
-        expected_result = {'child_table': 'transformed_rows'}
-
-        # Run
-        result = sampler.sample_rows('child_table', 5)
-
-        # Check
-        assert result == expected_result
-        assert sampler.sampled == {'table_name': 'samples'}
-
-        primary_mock.assert_called_once_with(sampler, 'child_table', 5)
-        parent_mock.assert_called_once_with(sampler, 'child_table')
-        sample_mock.assert_called_once_with(sampler, 'model from extension', 5, 'child_table')
-
-        expected_sample_info = ('primary_key', sample_mock.return_value)
-        update_mock.assert_called_once_with({}, 'child_table', expected_sample_info)
-        trans_mock.assert_called_once_with(sampler, sample_mock.return_value, 'child_table')
-
-        call_args_list = extension_mock.call_args_list
-        assert len(call_args_list) == 1
-        args, kwargs = call_args_list[0]
-        assert kwargs == {}
-        assert len(args) == 4
-        assert args[0] == sampler
-        assert args[1].equals(pd.DataFrame({'foreign_key': [0]}))
-        assert args[2] == 'child_table'
-        assert args[3] == 'parent_name'
-
-        model_mock.assert_called_once_with(sampler, 'extension')
 
     @patch('sdv.sampler.Sampler.sample_rows', autospec=True)
     def test_sample_all(self, rows_mock):
@@ -532,77 +349,6 @@ class TestSampler(TestCase):
         data_navigator.assert_not_called()
         modeler.assert_not_called()
 
-    def test__sample_valid_rows_respect_categorical_values(self):
-        """_sample_valid_rows will return rows with valid values for categorical columns."""
-        # Setup
-        data_navigator = MagicMock(spec=DataNavigator)
-        modeler = MagicMock(spec=Modeler)
-        sampler = Sampler(data_navigator, modeler)
-
-        data = pd.DataFrame(columns=['field_A', 'field_B'])
-        modeler.tables = {
-            'table_name': data,
-        }
-
-        data_navigator.meta = {
-            'tables': [
-                {
-                    'name': 'table_name',
-                    'fields': [
-                        {
-                            'name': 'field_A',
-                            'type': 'categorical'
-                        },
-                        {
-                            'name': 'field_B',
-                            'type': 'categorical'
-                        }
-                    ]
-                }
-            ]
-        }
-
-        num_rows = 5
-        table_name = 'table_name'
-        model = MagicMock(spec=GaussianMultivariate)
-        model.fitted = True
-        sample_dataframe = pd.DataFrame([
-            {'field_A': 0.5, 'field_B': 0.5},
-            {'field_A': 0.5, 'field_B': 0.5},
-            {'field_A': 0.5, 'field_B': 0.5},
-            {'field_A': 0.5, 'field_B': 1.5},  # Invalid field_B
-            {'field_A': 1.5, 'field_B': 0.5},  # Invalid field_A
-        ])
-
-        model.sample.side_effect = lambda x: sample_dataframe.iloc[:x].copy()
-
-        expected_model_call_args_list = [
-            ((5,), {}),
-            ((2,), {})
-        ]
-
-        expected_result = pd.DataFrame([
-            {'field_A': 0.5, 'field_B': 0.5},
-            {'field_A': 0.5, 'field_B': 0.5},
-            {'field_A': 0.5, 'field_B': 0.5},
-            {'field_A': 0.5, 'field_B': 0.5},
-            {'field_A': 0.5, 'field_B': 0.5},
-        ])
-
-        # Run
-        result = sampler._sample_valid_rows(model, num_rows, table_name)
-
-        # Check
-        assert result.equals(expected_result)
-
-        modeler.assert_not_called()
-        assert len(modeler.method_calls) == 0
-
-        data_navigator.assert_not_called()
-        assert len(data_navigator.method_calls) == 0
-
-        assert model.sample.call_args_list == expected_model_call_args_list
-
     def test__sample_valid_rows_raises_unfitted_model(self):
         """_sample_valid_rows raise an exception for invalid models."""
         # Setup
@@ -862,7 +608,7 @@ class TestSampler(TestCase):
         modeler = MagicMock(spec=Modeler)
         sampler = Sampler(data_navigator=data_navigator, modeler=modeler)
 
-        rows_mock.return_value = {'table': 'samples'}
+        rows_mock.return_value = 'samples'
 
         table_name = 'table'
         reset_primary_keys = False


### PR DESCRIPTION
Resolve #104 

Change how to number of rows is selected for each child table in order to support all scenarios.
Also, make partial sampling independent from previous sampling and avoid storing the sampled data within the Sampler class.